### PR TITLE
Bump version; set school zone limit to 20

### DIFF
--- a/WME-POI-Shortcuts.user.js
+++ b/WME-POI-Shortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name            WME POI Shortcuts
 // @namespace       https://greasyfork.org/users/45389
-// @version         2026.04.19.001
+// @version         2026.05.15.001
 // @description     Various UI changes to make editing faster and easier.
 // @author          kid4rm90s & copilot
 // @include         /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/
@@ -22,7 +22,7 @@
   ('use strict');
 
   const updateMessage = `
-      <strong>NEW :</strong><br>  - now it uses sdk version of link enhancer!<br>
+      <strong>NEW :</strong><br>  - Default speed limit for school zones set to 20 km/h!<br>
   `;
   const scriptName = GM_info.script.name;
   const scriptVersion = GM_info.script.version;
@@ -420,7 +420,7 @@
   let gleEnabled = false;
   let gleShowTempClosed = true;
   let openEditAddressOnRPP = false;
-  let schoolZoneSpeedLimit = 30;
+  let schoolZoneSpeedLimit = 20; // Default speed limit for school zones, can be customized in settings
   try {
     gleEnabled = JSON.parse(localStorage.getItem('wme-poi-shortcuts-gle-enabled'));
   } catch (e) {
@@ -442,7 +442,7 @@
       schoolZoneSpeedLimit = storedSpeedLimit;
     }
   } catch (e) {
-    schoolZoneSpeedLimit = 30;
+    schoolZoneSpeedLimit = 20; // Default school zone speed limit if parsing fails
   }
   let GLE = {
     enabled: gleEnabled,


### PR DESCRIPTION
Update script version metadata to 2026.05.15.001 and change the default schoolZoneSpeedLimit from 30 to 20 km/h. Add inline comments clarifying this default and that it can be customized in settings, and apply the same 20 km/h fallback in the catch block when parsing stored values fails.